### PR TITLE
Add support for AVIF

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ import png from './types/png.js';
 import jpeg from './types/jpeg.js';
 import gif from './types/gif.js';
 import webp from './types/webp.js';
+import avif from './types/avif.js';
 
 export function imageDimensionsFromData(bytes) {
 	// Prevent issues with Buffer being passed. Seems to be an issue on Node.js 20 and later.
@@ -11,7 +12,8 @@ export function imageDimensionsFromData(bytes) {
 	return png(bytes)
 		?? gif(bytes)
 		?? jpeg(bytes)
-		?? webp(bytes);
+		?? webp(bytes)
+		?? avif(bytes);
 }
 
 export async function imageDimensionsFromStream(stream) {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
 		"jpeg",
 		"jpg",
 		"gif",
-		"webp"
+		"webp",
+		"avif"
 	],
 	"devDependencies": {
 		"ava": "^5.3.1",

--- a/readme.md
+++ b/readme.md
@@ -90,6 +90,7 @@ npx image-dimensions unicorn.png
 - Smaller
 - Works in non-Node.js environments like the browser
 - Does not include unnecessary APIs for file reading
+- Supports the AVIF image format
 
 **Advantages of `image-size`**
 

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 
 *Works in any modern JavaScript environment (browsers, Node.js, Bun, Deno, etc).*
 
-Supporting all kinds of image formats is a non-goal. However, pull requests for adding JPEG XL, HEIC, and AVIF formats are welcome.
+Supporting all kinds of image formats is a non-goal. However, pull requests for adding JPEG XL, and HEIC formats are welcome.
 
 ## Supported formats
 
@@ -12,6 +12,7 @@ Supporting all kinds of image formats is a non-goal. However, pull requests for 
 - PNG (and APNG)
 - GIF
 - WebP
+- AVIF
 
 ## Install
 

--- a/test.js
+++ b/test.js
@@ -48,8 +48,8 @@ test.failing('jpeg xl', t => {
 	matches(t, 'jpeg xl/valid.jxl', {width: 30, height: 17});
 });
 
-test.failing('avif', t => {
-	matches(t, 'avif/valid.avif', {width: 30, height: 17});
+test('avif', t => {
+	matches(t, 'avif/valid.avif', {width: 30, height: 20});
 });
 
 test.failing('heic', t => {

--- a/types/avif.js
+++ b/types/avif.js
@@ -1,3 +1,5 @@
+// Specification: https://aomediacodec.github.io/av1-avif/v1.1.0.html
+
 const isAvif = bytes =>
 	// `ftypavif` magic bytes
 	bytes[4] === 0x66

--- a/types/avif.js
+++ b/types/avif.js
@@ -1,0 +1,142 @@
+const isAvif = bytes =>
+	// `ftypavif` magic bytes
+	bytes[4] === 0x66
+	&& bytes[5] === 0x74
+	&& bytes[6] === 0x79
+	&& bytes[7] === 0x70
+	&& bytes[8] === 0x61
+	&& bytes[9] === 0x76
+	&& bytes[10] === 0x69
+	&& bytes[11] === 0x66;
+
+export default function avif(bytes) {
+	if (!isAvif(bytes)) {
+		return;
+	}
+
+	const sizes = getMeta(bytes);
+
+	if (sizes.length === 0) {
+		return;
+	}
+
+	return getMaxSize(sizes);
+}
+
+function unbox(data, offset) {
+	if (data.length < 4 + offset) {
+		return;
+	}
+
+	const dataView = new DataView(data.buffer);
+	const size = dataView.getUint32(offset);
+
+	// Size includes the first 4 bytes (length)
+	if (data.length < size + offset || size < 8) {
+		return;
+	}
+
+	return {
+		type: String.fromCodePoint(...data.slice(offset + 4, offset + 8)),
+		data: data.slice(offset + 8, offset + size),
+		tail: offset + size,
+	};
+}
+
+function getMeta(data) {
+	const sizes = [];
+	let offset = 0;
+
+	while (offset < data.length) {
+		const box = unbox(data, offset);
+
+		if (!box) {
+			break;
+		}
+
+		if (box.type === 'meta') {
+			parseMetaBox(box.data, sizes);
+		}
+
+		offset = box.tail;
+	}
+
+	return sizes;
+}
+
+// Parses `meta` box
+function parseMetaBox(data, sizes) {
+	let offset = 4; // Version + flags
+
+	while (offset < data.length) {
+		const box = unbox(data, offset);
+
+		if (!box) {
+			break;
+		}
+
+		if (box.type === 'iprp') {
+			parseIprpBox(box.data, sizes);
+		}
+
+		offset = box.tail;
+	}
+
+	return sizes;
+}
+
+// Parses `meta.iprp` box (Item Properties)
+function parseIprpBox(data, sizes) {
+	let offset = 0;
+
+	while (offset < data.length) {
+		const box = unbox(data, offset);
+
+		if (!box) {
+			break;
+		}
+
+		if (box.type === 'ipco') {
+			parseIpcoBox(box.data, sizes);
+		}
+
+		offset = box.tail;
+	}
+}
+
+// Parses `meta.iprp.ipco` box (Item Property Container)
+function parseIpcoBox(data, sizes) {
+	let offset = 0;
+
+	while (offset < data.length) {
+		const box = unbox(data, offset);
+
+		if (!box) {
+			break;
+		}
+
+		// Image Spatial Extent
+		if (box.type === 'ispe') {
+			const dataView = new DataView(box.data.buffer);
+			sizes.push({
+				width: dataView.getUint32(4),
+				height: dataView.getUint32(8),
+			});
+		}
+
+		offset = box.tail;
+	}
+}
+
+// Get the image size with the largest area
+function getMaxSize(sizes) {
+	let maxSize = sizes[0];
+
+	for (const size of sizes) {
+		if (size.width * size.height > maxSize.width * maxSize.height) {
+			maxSize = size;
+		}
+	}
+
+	return maxSize;
+}


### PR DESCRIPTION
A similar approach should be able to be used for other ISO BMFF formats (HEIF, JXL, JPEG2000, MP4) however I suspect there may be some differences, like JPEG XL doesn't always include a `jxlc` codestream box. 🤔 