### PR TITLE
Improve error handling in `imageDimensionsFromData`

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,9 +17,10 @@ export function imageDimensionsFromData(bytes) {
 			?? avif(bytes);
 	} catch (error) {
 		if (error instanceof RangeError) {
-			// error from DataView methods
+			// Error from DataView methods
 			return;
 		}
+
 		throw error;
 	}
 }

--- a/index.js
+++ b/index.js
@@ -8,21 +8,12 @@ export function imageDimensionsFromData(bytes) {
 	// Prevent issues with Buffer being passed. Seems to be an issue on Node.js 20 and later.
 	bytes = new Uint8Array(bytes);
 
-	try {
-		// Note: Place types that can be detected fast first.
-		return png(bytes)
-			?? gif(bytes)
-			?? jpeg(bytes)
-			?? webp(bytes)
-			?? avif(bytes);
-	} catch (error) {
-		if (error instanceof RangeError) {
-			// Error from DataView methods
-			return;
-		}
-
-		throw error;
-	}
+	// Note: Place types that can be detected fast first.
+	return png(bytes)
+		?? gif(bytes)
+		?? jpeg(bytes)
+		?? webp(bytes)
+		?? avif(bytes);
 }
 
 export async function imageDimensionsFromStream(stream) {

--- a/index.js
+++ b/index.js
@@ -8,12 +8,20 @@ export function imageDimensionsFromData(bytes) {
 	// Prevent issues with Buffer being passed. Seems to be an issue on Node.js 20 and later.
 	bytes = new Uint8Array(bytes);
 
-	// Note: Place types that can be detected fast first.
-	return png(bytes)
-		?? gif(bytes)
-		?? jpeg(bytes)
-		?? webp(bytes)
-		?? avif(bytes);
+	try {
+		// Note: Place types that can be detected fast first.
+		return png(bytes)
+			?? gif(bytes)
+			?? jpeg(bytes)
+			?? webp(bytes)
+			?? avif(bytes);
+	} catch (error) {
+		if (error instanceof RangeError) {
+			// error from DataView methods
+			return;
+		}
+		throw error;
+	}
 }
 
 export async function imageDimensionsFromStream(stream) {

--- a/test.js
+++ b/test.js
@@ -73,9 +73,9 @@ test('webp - animated', t => {
 });
 
 test('imageDimensionsFromData - error handling on DataView methods', t => {
-	const data = fs.readFileSync('fixtures/png/valid.png').subarray(0, 20)
-	t.is(imageDimensionsFromData(data), undefined)
-})
+	const data = fs.readFileSync('fixtures/png/valid.png').subarray(0, 20);
+	t.is(imageDimensionsFromData(data), undefined);
+});
 
 test('imageDimensionsFromStream', async t => {
 	const stream = fs.createReadStream('fixtures/png/valid.png');

--- a/test.js
+++ b/test.js
@@ -72,6 +72,11 @@ test('webp - animated', t => {
 	matches(t, 'webp/animated.webp', {width: 30, height: 17});
 });
 
+test('imageDimensionsFromData - error handling on DataView methods', t => {
+	const data = fs.readFileSync('fixtures/png/valid.png').subarray(0, 20)
+	t.is(imageDimensionsFromData(data), undefined)
+})
+
 test('imageDimensionsFromStream', async t => {
 	const stream = fs.createReadStream('fixtures/png/valid.png');
 	t.deepEqual(await imageDimensionsFromStream(stream), {width: 30, height: 20});

--- a/types/avif.js
+++ b/types/avif.js
@@ -1,3 +1,5 @@
+import {getUint32} from '../utils.js';
+
 // Specification: https://aomediacodec.github.io/av1-avif/v1.1.0.html
 
 const isAvif = bytes =>
@@ -26,12 +28,12 @@ export default function avif(bytes) {
 }
 
 function unbox(data, offset) {
-	if (data.length < 4 + offset) {
+	const dataView = new DataView(data.buffer);
+	const size = getUint32(dataView, offset);
+
+	if (size === undefined) {
 		return;
 	}
-
-	const dataView = new DataView(data.buffer);
-	const size = dataView.getUint32(offset);
 
 	// Size includes the first 4 bytes (length)
 	if (data.length < size + offset || size < 8) {
@@ -120,9 +122,16 @@ function parseIpcoBox(data, sizes) {
 		// Image Spatial Extent
 		if (box.type === 'ispe') {
 			const dataView = new DataView(box.data.buffer);
+			const width = getUint32(dataView, 4);
+			const height = getUint32(dataView, 8);
+
+			if (width === undefined || height === undefined) {
+				return;
+			}
+
 			sizes.push({
-				width: dataView.getUint32(4),
-				height: dataView.getUint32(8),
+				width,
+				height,
 			});
 		}
 

--- a/types/gif.js
+++ b/types/gif.js
@@ -1,3 +1,5 @@
+import {getUint16} from '../utils.js';
+
 const isGif = bytes =>
 	bytes[0] === 0x47
 	&& bytes[1] === 0x49
@@ -13,8 +15,15 @@ export default function gif(bytes) {
 
 	const dataView = new DataView(bytes.buffer);
 
+	const width = getUint16(dataView, 6, true);
+	const height = getUint16(dataView, 8, true);
+
+	if (width === undefined || height === undefined) {
+		return;
+	}
+
 	return {
-		width: dataView.getUint16(6, true),
-		height: dataView.getUint16(8, true),
+		width,
+		height,
 	};
 }

--- a/types/png.js
+++ b/types/png.js
@@ -1,3 +1,5 @@
+import {getUint32} from '../utils.js';
+
 const isPng = bytes =>
 	bytes[0] === 0x89
 	&& bytes[1] === 0x50
@@ -23,8 +25,15 @@ export default function png(bytes) {
 	const dataView = new DataView(bytes.buffer);
 	const isAppleMinified = isAppleMinifiedPng(bytes);
 
+	const width = getUint32(dataView, isAppleMinified ? 32 : 16, false);
+	const height = getUint32(dataView, isAppleMinified ? 36 : 20, false);
+
+	if (width === undefined || height === undefined) {
+		return;
+	}
+
 	return {
-		width: dataView.getUint32(isAppleMinified ? 32 : 16, false),
-		height: dataView.getUint32(isAppleMinified ? 36 : 20, false),
+		width,
+		height,
 	};
 }

--- a/types/webp.js
+++ b/types/webp.js
@@ -1,3 +1,5 @@
+import {isValidOffsetToRead, getUint32} from '../utils.js';
+
 // Specification: https://developers.google.com/speed/webp/docs/riff_container
 
 const isWebp = bytes =>
@@ -52,6 +54,10 @@ export default function webp(bytes) {
 	const maxSize = 0x3F_FF;
 
 	if (isVP8Lossy(bytes)) {
+		if (!isValidOffsetToRead(dataView, 28, 2)) {
+			return;
+		}
+
 		return {
 			// eslint-disable-next-line no-bitwise
 			width: dataView.getUint16(26, true) & maxSize,
@@ -61,7 +67,11 @@ export default function webp(bytes) {
 	}
 
 	if (isVP8Lossless(bytes)) {
-		const bits = dataView.getUint32(21, true);
+		const bits = getUint32(dataView, 21, true);
+
+		if (bits === undefined) {
+			return;
+		}
 
 		return {
 			// eslint-disable-next-line no-bitwise
@@ -72,6 +82,10 @@ export default function webp(bytes) {
 	}
 
 	if (isVP8Extended(bytes)) {
+		if (!isValidOffsetToRead(dataView, 27, 3)) {
+			return;
+		}
+
 		return {
 			width: readUInt24LE(dataView, 24) + 1,
 			height: readUInt24LE(dataView, 27) + 1,

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,15 @@
+export function isValidOffsetToRead(dataView, offset, bytesToRead) {
+	return dataView.byteLength >= offset + bytesToRead;
+}
+
+export function getUint32(dataView, offset, littleEndian = false) {
+	if (isValidOffsetToRead(dataView, offset, 4)) {
+		return dataView.getUint32(offset, littleEndian);
+	}
+}
+
+export function getUint16(dataView, offset, littleEndian = false) {
+	if (isValidOffsetToRead(dataView, offset, 2)) {
+		return dataView.getUint16(offset, littleEndian);
+	}
+}


### PR DESCRIPTION
Passing an incomplete binary to `imageDimensionsFromData` can raise `RangeError` in the current implementation. This error can occur in particular through `imageDimensionsFromStream`.