### PR TITLE
Update the comparison with `image-size`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -86,11 +86,8 @@ npx image-dimensions unicorn.png
 
 **Advantages of this package**
 
-- Zero dependencies
 - Smaller
-- Works in non-Node.js environments like the browser
 - Does not include unnecessary APIs for file reading
-- Supports the AVIF image format
 
 **Advantages of `image-size`**
 


### PR DESCRIPTION
Hi, I'm a maintainer of `image-size`. 
I just discovered this package, and noticed that the comparison with `image-size` was a bit outdated.
The latest version of `image-size` does not have any dependencies, works in browsers, and has supported AVIF/HEIC since over a year.