### PR TITLE
fix: handle Safari async iterable stream error

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,18 @@ export function imageDimensionsFromData(bytes) {
 export async function imageDimensionsFromStream(stream) {
 	let buffer = new Uint8Array(0);
 
-	for await (const chunk of stream) {
+	// Check if stream supports async iteration (not supported in Safari)
+	// https://caniuse.com/wf-async-iterable-streams
+	const asyncIterator = stream[Symbol.asyncIterator]?.() ?? stream[Symbol.iterator]?.();
+
+	if (!asyncIterator) {
+		throw new TypeError('Expected an async or sync iterable stream');
+	}
+
+	// Use async iteration if available, otherwise fall back to sync iteration
+	const iteratorMethod = asyncIterator[Symbol.asyncIterator] ? 'async' : 'sync';
+
+	for await (const chunk of (iteratorMethod === 'async' ? stream : [stream])) {
 		// Merge chunks
 		const newBuffer = new Uint8Array(buffer.length + chunk.length);
 		newBuffer.set(buffer);
@@ -39,3 +50,4 @@ export async function imageDimensionsFromStream(stream) {
 		}
 	}
 }
+


### PR DESCRIPTION
## Summary

Safari does not support async iterable streams (`for await...of` on streams).
This causes `TypeError: undefined is not a function` when calling
`imageDimensionsFromStream` in Safari.

## Changes

- Added detection for async iterator support using `Symbol.asyncIterator`
- Falls back to `Symbol.iterator` for sync iterable streams
- Throws a clear `TypeError` if stream is not iterable

## Testing

The fix can be tested by running the function in Safari or other
browsers that don't support async iterable streams.

## Fixes

Fixes #16