### PR TITLE
Add support for Safari non-async iterable web streams

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,21 +30,26 @@ export function imageDimensionsFromData(bytes) {
  */
 async function * asyncIterableFromStream(stream) {
 	const reader = stream.getReader();
+	let finished = false;
 
 	try {
-		let running = true;
-		while (running) {
+		while (!finished) {
 			// eslint-disable-next-line no-await-in-loop -- Chunks must be read in order to know `done`
 			const {done, value} = await reader.read();
 
 			if (done) {
-				running = false;
+				finished = true;
 				break;
 			}
 
 			yield value;
 		}
 	} finally {
+		// Cancel stream if consumer exited early
+		if (!finished) {
+			await reader.cancel();
+		}
+
 		reader.releaseLock();
 	}
 }

--- a/index.js
+++ b/index.js
@@ -23,10 +23,39 @@ export function imageDimensionsFromData(bytes) {
 		?? heic(bytes);
 }
 
+/**
+ * Web streams are not async iterable in Safari (iOS, Desktop) as of 2026-05-10
+ *
+ * @see {@link https://caniuse.com/wf-async-iterable-streams}
+ */
+async function * asyncIterableFromStream(stream) {
+	const reader = stream.getReader();
+
+	try {
+		let running = true;
+		while (running) {
+			// eslint-disable-next-line no-await-in-loop -- Chunks must be read in order to know `done`
+			const {done, value} = await reader.read();
+
+			if (done) {
+				running = false;
+				break;
+			}
+
+			yield value;
+		}
+	} finally {
+		reader.releaseLock();
+	}
+}
+
 export async function imageDimensionsFromStream(stream) {
 	let buffer = new Uint8Array(0);
 
-	for await (const chunk of stream) {
+	const asyncIterableStream
+		= Symbol.asyncIterator in stream ? stream : asyncIterableFromStream(stream);
+
+	for await (const chunk of asyncIterableStream) {
 		// Merge chunks
 		const newBuffer = new Uint8Array(buffer.length + chunk.length);
 		newBuffer.set(buffer);

--- a/test.js
+++ b/test.js
@@ -90,6 +90,12 @@ test('imageDimensionsFromStream - web stream', async t => {
 	t.deepEqual(await imageDimensionsFromStream(stream), {width: 30, height: 20, type: 'png'});
 });
 
+test('imageDimensionsFromStream - web stream non-async iterable', async t => {
+	const stream = ReadableStream.from(fs.createReadStream('fixtures/png/valid.png'));
+	delete stream[Symbol.asyncIterator];
+	t.deepEqual(await imageDimensionsFromStream(stream), {width: 30, height: 20, type: 'png'});
+});
+
 test('empty', t => {
 	t.notThrows(() => {
 		imageDimensionsFromData(new Uint8Array());

--- a/test.js
+++ b/test.js
@@ -96,6 +96,25 @@ test('imageDimensionsFromStream - web stream non-async iterable', async t => {
 	t.deepEqual(await imageDimensionsFromStream(stream), {width: 30, height: 20, type: 'png'});
 });
 
+test('imageDimensionsFromStream - web stream non-async iterable cancels early', async t => {
+	let canceled = false;
+	const data = await fs.promises.readFile('fixtures/png/valid.png');
+	const stream = new ReadableStream({
+		start(controller) {
+			controller.enqueue(data);
+			// Never closes
+		},
+		cancel() {
+			canceled = true;
+		},
+	});
+
+	delete ReadableStream.prototype[Symbol.asyncIterator];
+
+	t.deepEqual(await imageDimensionsFromStream(stream), {width: 30, height: 20, type: 'png'});
+	t.true(canceled);
+});
+
 test('empty', t => {
 	t.notThrows(() => {
 		imageDimensionsFromData(new Uint8Array());

--- a/test.js
+++ b/test.js
@@ -92,7 +92,7 @@ test('imageDimensionsFromStream - web stream', async t => {
 
 test('imageDimensionsFromStream - web stream non-async iterable', async t => {
 	const stream = ReadableStream.from(fs.createReadStream('fixtures/png/valid.png'));
-	delete stream[Symbol.asyncIterator];
+	delete ReadableStream.prototype[Symbol.asyncIterator];
 	t.deepEqual(await imageDimensionsFromStream(stream), {width: 30, height: 20, type: 'png'});
 });
 


### PR DESCRIPTION
- Closes #16
- Adds support for non-async iterable web streams (Safari iOS and Desktop) by converting stream to async iterable
- Add test for web stream non-async readable